### PR TITLE
CircleCI docker_layer_caching無効化

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ jobs:
       - checkout
 
       - setup_remote_docker:
-         docker_layer_caching: true
          version: 18.09.3
 
       - run: make


### PR DESCRIPTION
無料プランではCircleCIのdocker_layer_cachingが使えなくなった

https://circleci.com/gh/pinkumohikan/sunfish/27?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

![image](https://user-images.githubusercontent.com/7835241/69203549-f957e900-0b87-11ea-9c96-ceae4cb28249.png)

see: https://blog.pinkumohikan.com/entry/expensive-circleci-docker-layer-caching
