### PR TITLE
make docker/upが環境依存になってた

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: docker/* setup try dev
 
 docker/up:
-	docker-compose up --d --build
+	docker-compose up --detach --build
 
 docker/down:
 	docker-compose down
@@ -14,16 +14,16 @@ docker/ping:
 	until [ $$(docker ps -q) ]; do sleep 1 && echo "waiting for up container"; done
 	docker exec $$(docker ps -q) curl -sSf --retry 5 --retry-connrefused -o /dev/null --dump-header - http://localhost/margin_stocks
 
-
 setup: composer.phar
 	./composer.phar install --no-dev --prefer-dist --optimize-autoloader --no-interaction
-
-composer.phar:
-	./script/setup-composer.sh
-
 
 try:
 	php bin/try.php
 
 dev:
 	php -S 0.0.0.0:8080 -t ./public
+
+
+# DO NOT .PHONY
+composer.phar:
+	./script/setup-composer.sh


### PR DESCRIPTION
docker-compose upのdetachオプションは `-d` であって `--d` ではないやで

手元のdocker for macだと `--d` でも動いたので気づかなかった